### PR TITLE
Add simple Node.js webapp with email form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# codex-test-2
+# Simple Webapp
+
+This project contains a minimal Node.js server that serves a static page with an interactive form. The form accepts an email ending with `@infracommerce.lat` and fetches results from a remote endpoint.
+
+## How to run
+
+1. Ensure you have Node.js installed.
+2. Start the server:
+   ```bash
+   node index.js
+   ```
+3. Open `http://localhost:3000` in your browser.
+
+## Project Structure
+- `index.js` – simple HTTP server
+- `public/index.html` – form and result display
+- `public/style.css` – pastel styling
+- `public/main.js` – client-side validation and fetch logic
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,29 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(__dirname, 'public', req.url === '/' ? 'index.html' : req.url);
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not Found');
+      } else {
+        res.writeHead(500);
+        res.end('Server Error');
+      }
+    } else {
+      let ext = path.extname(filePath);
+      let contentType = 'text/html';
+      if (ext === '.css') contentType = 'text/css';
+      if (ext === '.js') contentType = 'text/javascript';
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex-test-2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Simple Form</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <form id="dataForm">
+      <label for="email">Email:</label>
+      <input type="email" id="email" name="email" required>
+      <span id="error" class="error"></span>
+      <button type="submit">Submit</button>
+    </form>
+    <pre id="result"></pre>
+  </div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,21 @@
+document.getElementById('dataForm').addEventListener('submit', async function(e) {
+  e.preventDefault();
+  const emailInput = document.getElementById('email');
+  const errorSpan = document.getElementById('error');
+  const resultPre = document.getElementById('result');
+  const email = emailInput.value.trim();
+  if(!email.endsWith('@infracommerce.lat')) {
+    errorSpan.textContent = 'Email must end with @infracommerce.lat';
+    resultPre.textContent = '';
+    return;
+  }
+  errorSpan.textContent = '';
+  try {
+    const response = await fetch('https://n8n.ifc-tech.lat/webhook/cencosud-sameday-check');
+    if(!response.ok) throw new Error('Network response was not ok');
+    const data = await response.json();
+    resultPre.textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    resultPre.textContent = 'Error: ' + err.message;
+  }
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,44 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f7f7ff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+.container {
+  background-color: #e8e8f9;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+label {
+  display: block;
+  margin-bottom: 5px;
+}
+input {
+  padding: 8px;
+  margin-bottom: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+button {
+  background-color: #b8c0ff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #fff;
+}
+.error {
+  color: red;
+  display: block;
+  margin-bottom: 10px;
+}
+pre {
+  background: #fff;
+  padding: 10px;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- create minimal HTTP server
- add pastel-styled form that validates `@infracommerce.lat` emails
- fetch webhook results on submit and display JSON
- document setup in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68406f0dddc4832f9747a94ef9119ed0